### PR TITLE
Fixes breaking change in 0.40

### DIFF
--- a/ios/TextToSpeech/TextToSpeech.h
+++ b/ios/TextToSpeech/TextToSpeech.h
@@ -6,8 +6,8 @@
 //  Copyright © 2016 Anton Krasovsky. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
-#import "RCTEventEmitter.h"
+#import "React/RCTBridgeModule.h"
+#import "React/RCTEventEmitter.h"
 
 @import AVFoundation;
 

--- a/ios/TextToSpeech/TextToSpeech.m
+++ b/ios/TextToSpeech/TextToSpeech.m
@@ -6,9 +6,9 @@
 //  Copyright © 2016 Anton Krasovsky. All rights reserved.
 //
 
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
-#import "RCTLog.h"
+#import "React/RCTBridge.h"
+#import "React/RCTEventDispatcher.h"
+#import "React/RCTLog.h"
 
 #import "TextToSpeech.h"
 


### PR DESCRIPTION
Fixes breaking change in 0.40 by referring to headers out of the react namespace.

Addresses #7 

I know you are aware of this problem.  I stumbled across this pulling it into a new project just now.  Needed to host it somewhere for yarn for now, so figured I'd PR it.  Feel free to close if you want to change it yourself.