### PR TITLE
Fixed setDefaultLanguage not rejecting the promise on Android when an invalid language was specified

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -96,8 +96,22 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
         }
 
         int result = tts.setLanguage(locale);
-
-        promise.resolve(result); // todo turn result to string
+        switch (result) {
+        case TextToSpeech.LANG_AVAILABLE:
+        case TextToSpeech.LANG_COUNTRY_AVAILABLE:
+        case TextToSpeech.LANG_COUNTRY_VAR_AVAILABLE:
+            promise.resolve("success");
+            break;
+        case TextToSpeech.LANG_MISSING_DATA:
+            promise.reject("not_found", "Language data is missing");
+            break;
+        case TextToSpeech.LANG_NOT_SUPPORTED:
+            promise.reject("not_found", "Language is not supported");
+            break;
+        default:
+            promise.reject("error", "Unknown error code");
+            break;
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
Hi,

This pull request fixes the promise result of the `setDefaultLanguage` function on Android. The function now rejects the promise in case the language could not be set, and additionally returns more detailed error strings.

cheers,
Hein