### PR TITLE
Lower volume of other apps while TTS is playing

### DIFF
--- a/ios/TextToSpeech/TextToSpeech.m
+++ b/ios/TextToSpeech/TextToSpeech.m
@@ -29,6 +29,11 @@ RCT_EXPORT_MODULE()
     if (self) {
         _synthesizer = [AVSpeechSynthesizer new];
         _synthesizer.delegate = self;
+        
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        [session setCategory:AVAudioSessionCategoryPlayback
+                      withOptions:AVAudioSessionCategoryOptionDuckOthers
+                            error:nil];
     }
 
     return self;
@@ -43,7 +48,7 @@ RCT_EXPORT_METHOD(speak:(NSString *)text
         reject(@"no_text", @"No text to speak", nil);
         return;
     }
-
+    
     AVSpeechUtterance *utterance = [[AVSpeechUtterance alloc] initWithString:text];
 
     if(voice) {
@@ -152,21 +157,29 @@ RCT_EXPORT_METHOD(voices:(RCTPromiseResolveBlock)resolve
 
 -(void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didStartSpeechUtterance:(AVSpeechUtterance *)utterance
 {
+    [[AVAudioSession sharedInstance] setActive:YES error:nil];
+    
     [self sendEventWithName:@"tts-start" body:@{@"utteranceId":[NSNumber numberWithUnsignedLong:utterance.hash]}];
 }
 
 -(void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didFinishSpeechUtterance:(AVSpeechUtterance *)utterance
 {
+    [[AVAudioSession sharedInstance] setActive:NO error:nil];
+    
     [self sendEventWithName:@"tts-finish" body:@{@"utteranceId":[NSNumber numberWithUnsignedLong:utterance.hash]}];
 }
 
 -(void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didPauseSpeechUtterance:(AVSpeechUtterance *)utterance
 {
+    [[AVAudioSession sharedInstance] setActive:NO error:nil];
+    
     [self sendEventWithName:@"tts-pause" body:@{@"utteranceId":[NSNumber numberWithUnsignedLong:utterance.hash]}];
 }
 
 -(void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didContinueSpeechUtterance:(AVSpeechUtterance *)utterance
 {
+    [[AVAudioSession sharedInstance] setActive:YES error:nil];
+    
     [self sendEventWithName:@"tts-resume" body:@{@"utteranceId":[NSNumber numberWithUnsignedLong:utterance.hash]}];
 }
 
@@ -180,6 +193,8 @@ RCT_EXPORT_METHOD(voices:(RCTPromiseResolveBlock)resolve
 
 -(void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didCancelSpeechUtterance:(AVSpeechUtterance *)utterance
 {
+    [[AVAudioSession sharedInstance] setActive:NO error:nil];
+    
     [self sendEventWithName:@"tts-cancel" body:@{@"utteranceId":[NSNumber numberWithUnsignedLong:utterance.hash]}];
 }
 


### PR DESCRIPTION
Currently the `speak` method has unpredictable results if another app is playing audio (e.g. music is playing). This PR fixes the issue on both platforms by lowering the volume of the competing audio/app while the utterance is playing, then bringing the competing audio's volume back to normal once the utterance has finished/stopped/cancelled