### PR TITLE
Changing ACAudioSession Category

### DIFF
--- a/ios/TextToSpeech.m
+++ b/ios/TextToSpeech.m
@@ -111,7 +111,7 @@ RCT_EXPORT_METHOD(setDucking:(BOOL *)ducking
     
     if(ducking) {
         AVAudioSession *session = [AVAudioSession sharedInstance];
-        [session setCategory:AVAudioSessionCategoryPlayback
+        [session setCategory:AVAudioSessionCategorySoloAmbient
                  withOptions:AVAudioSessionCategoryOptionDuckOthers
                        error:nil];
     }

--- a/ios/TextToSpeech/TextToSpeech.m
+++ b/ios/TextToSpeech/TextToSpeech.m
@@ -107,7 +107,7 @@ RCT_EXPORT_METHOD(setDucking:(BOOL *)ducking
     
     if(ducking) {
         AVAudioSession *session = [AVAudioSession sharedInstance];
-        [session setCategory:AVAudioSessionCategoryPlayback
+        [session setCategory:AVAudioSessionCategorySoloAmbient
                  withOptions:AVAudioSessionCategoryOptionDuckOthers
                        error:nil];
     }


### PR DESCRIPTION
Changing ACAudioSession Category from 'AVAudioSessionCategoryPlayback' to 'AVAudioSessionCategorySoloAmbient' when Ducking.

'`AVAudioSessionCategorySoloAmbient`' seems to work when switching with `SFSpeechRecognizer`