### PR TITLE
Fix android build in RN 0.47

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechPackage.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechPackage.java
@@ -19,7 +19,7 @@ public class TextToSpeechPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
+  // Deprecated in RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
This function is no longer around in rn 0.47 so the override will
throw.  However, we must leave the actual function def in to support
older versions of rn.