### PR TITLE
Added ‘quality’ to Tts.voices() + additional Android fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,21 @@ Tts.voices().then(voices => console.log(voices));
 
 // Prints:
 //
-// [ { id: 'com.apple.ttsbundle.Moira-compact', name: 'Moira', language: 'en-IE' },
+// [ { id: 'com.apple.ttsbundle.Moira-compact', name: 'Moira', language: 'en-IE', quality: 300 },
 // ...
 // { id: 'com.apple.ttsbundle.Samantha-compact', name: 'Samantha', language: 'en-US' } ]
 ```
+
+|Voice field|Description|
+|-----|-----------|-------|
+|id   |Unique voice identifier (e.g. `com.apple.ttsbundle.Moira-compact`)|
+|name |Name of the voice *(iOS only)*|
+|language|BCP-47 language code (e.g. 'en-US')|
+|quality|Voice quality (300 = normal, 500 = enhanced/very high)|
+|latency|Expected synthesizer latency (100 = very low, 500 = very high) *(Android only)*|
+|networkConnectionRequired|True when the voice requires an active network connection *(Android only)*|
+|notInstalled|True when the voice may need to download additional data to be fully functional *(Android only)*|
+
 
 ### Set default Language
 

--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -221,6 +221,10 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
                     voiceMap.putString("id", voice.getName());
                     voiceMap.putString("name", voice.getName());
                     voiceMap.putString("language", voice.getLocale().toLanguageTag());
+                    voiceMap.putInt("quality", voice.getQuality());
+                    voiceMap.putInt("latency", voice.getLatency());
+                    voiceMap.putBoolean("networkConnectionRequired", voice.isNetworkConnectionRequired());
+                    voiceMap.putBoolean("notInstalled", voice.getFeatures().contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED));
                     voiceArray.pushMap(voiceMap);
                 }
             } catch (Exception e) {

--- a/ios/TextToSpeech/TextToSpeech.m
+++ b/ios/TextToSpeech/TextToSpeech.m
@@ -179,7 +179,12 @@ RCT_EXPORT_METHOD(voices:(RCTPromiseResolveBlock)resolve
     NSMutableArray *voices = [NSMutableArray new];
     
     for (AVSpeechSynthesisVoice *voice in [AVSpeechSynthesisVoice speechVoices]) {
-        [voices addObject:@{@"id": voice.identifier, @"name": voice.name, @"language": voice.language}];
+        [voices addObject:@{
+            @"id": voice.identifier,
+            @"name": voice.name,
+            @"language": voice.language,
+            @"quality": (voice.quality == AVSpeechSynthesisVoiceQualityEnhanced) ? @500 : @300
+        }];
     }
     
     resolve(voices);


### PR DESCRIPTION
Hi, this pull requests adds some additional return fields to `Tts.voices` so we can filter on the available voices better. This is especially important on Android where you sometimes want to select only the high quality voices, or the ones that are fully installed.

Previously only id, name and language were returned. This PR adds quality for iOS and Android:
- quality (number, range 100-500, 300 = normal, 500 = android very high/iOS enhanced)

And the following Android specific fields:
- latency (maps directly to the Android latency constants)
- notInstalled (True when voice is not fully installed)
- networkConnectionRequired (True when the voice needs a network connection to function)

regards, Hein