### PR TITLE
[BREAKING] Initialization promise on android

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -36,14 +36,19 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
     public TextToSpeechModule(ReactApplicationContext reactContext) {
         super(reactContext);
         audioManager = (AudioManager) reactContext.getApplicationContext().getSystemService(reactContext.AUDIO_SERVICE);
+    }
 
+    @ReactMethod
+    public void initialize(final Promise promise) {
         tts = new TextToSpeech(getReactApplicationContext(), new TextToSpeech.OnInitListener() {
             @Override
             public void onInit(int status) {
                 if (status != TextToSpeech.SUCCESS) {
                     ready = false;
+                    promise.reject("TTS failed to initialize");
                 } else {
                     ready = true;
+                    promise.resolve(true);
                 }
             }
         });
@@ -78,7 +83,6 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
                 sendEvent("tts-cancel", utteranceId);
             }
         });
-
     }
 
     @Override

--- a/index.js
+++ b/index.js
@@ -7,6 +7,13 @@ class Tts extends NativeEventEmitter {
     super(TextToSpeech);
   }
 
+  initialize() {
+    if (Platform.OS === 'ios') {
+      return Promise.resolve(true);
+    }
+    return TextToSpeech.initialize();
+  }
+
   setDucking(enabled) {
     return TextToSpeech.setDucking(enabled);
   }


### PR DESCRIPTION
On android the initialization code is called in the constructor, which is executed when the JS module is imported.  However, the initialization is asynchronous which means that the JS code may proceed and wind up calling other TTS functions without realizing that the engine is not yet initialized.

This PR moves the initialization to an explicit method which returns a promise which is resolved when initialization is complete.  This way, one can easily chain subsequent calls without any race conditions (and detect when TTS is not available).