### PR TITLE
added requiresMainQueueSetup with RN 0.49+ requirement when constantsToExport overridden

### DIFF
--- a/ios/TextToSpeech/TextToSpeech.m
+++ b/ios/TextToSpeech/TextToSpeech.m
@@ -35,6 +35,11 @@ RCT_EXPORT_MODULE()
     return self;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_METHOD(speak:(NSString *)text
                   voice:(NSString *)voice
                   resolve:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
Fixes https://github.com/ak1394/react-native-tts/issues/41