### PR TITLE
Fix crash on Tts.stop and Tts.pause when onWordBoundary=true on iOS

### DIFF
--- a/ios/TextToSpeech/TextToSpeech.m
+++ b/ios/TextToSpeech/TextToSpeech.m
@@ -74,7 +74,7 @@ RCT_EXPORT_METHOD(stop:(BOOL *)onWordBoundary resolve:(RCTPromiseResolveBlock)re
 {
     AVSpeechBoundary boundary;
 
-    if(onWordBoundary != NULL && *onWordBoundary) {
+    if(onWordBoundary != NULL && onWordBoundary) {
         boundary = AVSpeechBoundaryWord;
     } else {
         boundary = AVSpeechBoundaryImmediate;
@@ -89,7 +89,7 @@ RCT_EXPORT_METHOD(pause:(BOOL *)onWordBoundary resolve:(RCTPromiseResolveBlock)r
 {
     AVSpeechBoundary boundary;
 
-    if(onWordBoundary != NULL && *onWordBoundary) {
+    if(onWordBoundary != NULL && onWordBoundary) {
         boundary = AVSpeechBoundaryWord;
     } else {
         boundary = AVSpeechBoundaryImmediate;


### PR DESCRIPTION
Calling Tts.stop(true) results in an EXC_BAD_ACCESS.

This param isn't in the docs but I found it to be useful because calling Tts.stop() with no param (which internally calls stopSpeakingAtBoundary with AVSpeechBoundaryImmediate) caused my app to hang for 2 seconds each time, while replacing with AVSpeechBoundaryWord solved this.