### PR TITLE
Properly resolving promise for calls to setDefaultEngine

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -335,7 +335,7 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setDefaultEngine(String engineName, Promise promise) {
+    public void setDefaultEngine(String engineName, final Promise promise) {
         if(notReady(promise)) return;
 
         if(isPackageInstalled(engineName)) {
@@ -350,6 +350,7 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
                             resolveReadyPromise(p);
                         }
                         initStatusPromises.clear();
+                        promise.resolve(ready);
                     }
                 }
             }, engineName);


### PR DESCRIPTION
I think that the recent modifications for changing the default engine have a small issue, as they are not resolving the promise. 
For example, the following scenario doesn't work and waits forever:

```
await Tts.getInitStatus();
await Tts.setDefaultEngine(myPreferredEngine);
```

I am not sure about the need of the call to `resolveReadyPromise`, as I suspect it is only needed in the initialisation and not here, however I decided to leave it there for now (see comment in the code).