### PR TITLE
Conform return types between IOS and Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,9 +56,10 @@ class Tts extends NativeEventEmitter {
   }
 
   setIgnoreSilentSwitch(ignoreSilentSwitch) {
-    if (Platform.OS === 'ios' && ignoreSilentSwitch) {
+    if (platform.OS === 'ios') {
       return TextToSpeech.setIgnoreSilentSwitch(ignoreSilentSwitch);
     }
+    return Promise.resolve(true);
   }
 
   voices() {

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class Tts extends NativeEventEmitter {
   }
 
   setIgnoreSilentSwitch(ignoreSilentSwitch) {
-    if (platform.OS === 'ios') {
+    if (Platform.OS === 'ios') {
       return TextToSpeech.setIgnoreSilentSwitch(ignoreSilentSwitch);
     }
     return Promise.resolve(true);

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class Tts extends NativeEventEmitter {
 
   engines() {
     if (Platform.OS === 'ios') {
-      return Promise.resolve(true);
+      return Promise.resolve([]);
     }
     return TextToSpeech.engines();
   }

--- a/index.js
+++ b/index.js
@@ -102,14 +102,14 @@ class Tts extends NativeEventEmitter {
     if (Platform.OS === 'ios') {
       return TextToSpeech.pause(onWordBoundary);
     }
-    return null;
+    return Promise.resolve(false);
   }
 
   resume() {
     if (Platform.OS === 'ios') {
       return TextToSpeech.resume();
     }
-    return null;
+    return Promise.resolve(false);
   }
 
   addEventListener(type, handler) {


### PR DESCRIPTION
Not sure if this is wanted. Tried to make some typescript typings for this lib and sometimes there are different return types depending on if we are on IOS or Android. So this PR is just to try to make sure that the return types are compatible between the different platforms.
Maybe we want reject if we try to call an Android only function in IOS? Not sure, but I made it so that they at least return the same type now. 