### PR TITLE
bugFix node_modules\react-native-tts\android\src\main\java\net\no_mad…

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -395,8 +395,8 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
         if(notReady(promise)) return;
 
         int result = tts.stop();
-        boolean resultValue = (status == TextToSpeech.SUCCESS) ? Boolean.TRUE : Boolean.FALSE;
-        promise.resolve(result);
+        boolean resultValue = (result == TextToSpeech.SUCCESS) ? Boolean.TRUE : Boolean.FALSE;
+        promise.resolve(resultValue);
     }
 
     @ReactMethod


### PR DESCRIPTION
…\tts\TextToSpeechModule.java:398: error: cannot find symbol

        boolean resultValue = (status == TextToSpeech.SUCCESS) ? Boolean.TRUE : Boolean.FALSE;