### PR TITLE
windows: fix build for react-native-windows 0.62

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Run tests
       run: |
         cd example
-        yarn test:windows 
+        yarn test:windows_nosound_ci

--- a/example/__tests__/TestTTSInit.test.js
+++ b/example/__tests__/TestTTSInit.test.js
@@ -1,0 +1,22 @@
+import { driver, By2 } from 'selenium-appium'
+
+const setup = require('../jest-setups/jest.setup');
+jest.setTimeout(50000);
+
+beforeAll(() => {
+  return driver.startWithCapabilities(setup.capabilites);
+});
+
+afterAll(() => {
+  return driver.quit();
+});
+
+describe('Test App', () => {
+
+  test('Initializes TTS', async () => {
+    await driver.sleep(500);
+    let status = await By2.nativeAccessibilityId("Status").getText();
+    expect(status).toBe("Status: initialized")
+  });
+
+})

--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,8 @@
     "appium": "appium",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
-    "test:windows": "yarn jest --setupFiles=./jest-setups/jest.setup.windows.js"
+    "test:windows": "yarn jest --setupFiles=./jest-setups/jest.setup.windows.js --runInBand",
+    "test:windows_nosound_ci": "yarn jest __tests__/TestTTSInit.test.js --setupFiles=./jest-setups/jest.setup.windows.js"
   },
   "dependencies": {
     "react": "16.13.1",

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-tts": "1.5.0",
+    "react-native-tts": "../",
     "react-native-windows": "^0.63.0-0"
   },
   "devDependencies": {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -8733,9 +8733,8 @@ react-is@^16.3.1:
   version "16.4.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.4.0.tgz#cc9fdc855ac34d2e7d9d2eb7059bbc240d35ffcf"
 
-react-native-tts@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/react-native-tts/-/react-native-tts-1.5.0.tgz#1eb8b163e262f2ef7a73b48a090ffb6ff2bb8fac"
+react-native-tts@../:
+  version "4.0.0"
 
 react-native-windows@^0.63.0-0:
   version "0.63.17"

--- a/windows/RNTTS/RNTTS.cpp
+++ b/windows/RNTTS/RNTTS.cpp
@@ -177,10 +177,10 @@ void RNTTS::RNTTS::Resume(ReactPromise<JSValue> promise) noexcept
     promise.Resolve("success");
 }
 
-IAsyncAction RNTTS::RNTTS::SpeakAsync(winrt::hstring text, ReactPromise<JSValue> promise) noexcept
+winrt::Windows::Foundation::IAsyncAction RNTTS::RNTTS::SpeakAsync(winrt::hstring text, ReactPromise<JSValue> promise) noexcept
 {
     // Generate the audio stream from plain text.
-    IAsyncOperation<SpeechSynthesisStream> task{ speechSynthesizer.SynthesizeTextToStreamAsync(text) };
+    winrt::Windows::Foundation::IAsyncOperation<SpeechSynthesisStream> task{ speechSynthesizer.SynthesizeTextToStreamAsync(text) };
 
     SpeechSynthesisStream speechStream = co_await task;
 

--- a/windows/RNTTS/RNTTS.h
+++ b/windows/RNTTS/RNTTS.h
@@ -26,7 +26,7 @@ namespace winrt::RNTTS {
 
     RNTTS();
 
-    IAsyncAction SpeakAsync(winrt::hstring text, ReactPromise<JSValue> promise) noexcept;
+    winrt::Windows::Foundation::IAsyncAction SpeakAsync(winrt::hstring text, ReactPromise<JSValue> promise) noexcept;
     void OnMediaElementStateChanged(MediaPlaybackSession session,
         winrt::Windows::Foundation::IInspectable const& result) noexcept;
 


### PR DESCRIPTION
Fixes build errors when using `react-native-tts` on `react-native-windows 0.62`.