### PR TITLE
Android tts-progress event.

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -92,9 +92,6 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
 
                 @Override
                 public void onRangeStart (String utteranceId, int start, int end, int frame) {
-                  if(ducking) {
-                        audioManager.abandonAudioFocus(afChangeListener);
-                    }
                     sendEvent("tts-progress", utteranceId);
                 }
             });

--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -92,7 +92,12 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
 
                 @Override
                 public void onRangeStart (String utteranceId, int start, int end, int frame) {
-                    sendEvent("tts-progress", utteranceId);
+                    WritableMap params = Arguments.createMap();
+                    params.putString("utteranceId", utteranceId);
+                    params.putInt("start", start);
+                    params.putInt("end", end);
+                    params.putInt("frame", frame);
+                    sendEvent("tts-progress", params);
                 }
             });
         }
@@ -512,6 +517,10 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
     private void sendEvent(String eventName, String utteranceId) {
         WritableMap params = Arguments.createMap();
         params.putString("utteranceId", utteranceId);
+        sendEvent(eventName, params);
+    }
+
+    private void sendEvent(String eventName, WritableMap params) {
         getReactApplicationContext()
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(eventName, params);

--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -89,6 +89,14 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
                     }
                     sendEvent("tts-cancel", utteranceId);
                 }
+
+                @Override
+                public void onRangeStart (String utteranceId, int start, int end, int frame) {
+                  if(ducking) {
+                        audioManager.abandonAudioFocus(afChangeListener);
+                    }
+                    sendEvent("tts-progress", utteranceId);
+                }
             });
         }
     }


### PR DESCRIPTION
I've noticed that android is not triggering the tts-progress event. One could use the `onRangeStart` method to trigger the event.

I've tested succesfully on my project where I have a progress bar that gets updated for each word.
