### PR TITLE
Feature/iosParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Additionally, speak() allows to pass platform-specific options.
 Tts.speak('Hello, world!', {
   iosVoiceId: 'com.apple.ttsbundle.Moira-compact',
   rate: 0.5,
+  audioOutput: 'speaker',
 });
 // Android
 Tts.speak('Hello, world!', {
@@ -79,6 +80,8 @@ The supported options for IOS are:
 
 - `iosVoiceId` which voice to use, check [voices()](#list-voices) for available values
 - `rate` which speech rate this line should be spoken with. Will override [default rate](#set-default-speech-rate) if set for this utterance.
+
+- `audioOutput` you can use either `earpiece` or `speaker`. Default one is `speaker`. To enable the earpiece you need to set `Tts.setIgnoreSilentSwitch("ignore");`
 
 Stop speaking and flush the TTS queue.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,11 +76,19 @@ export type AndroidOptions = {
   KEY_PARAM_PAN: number;
 };
 
+export type IosOptions = {
+  /** Parameter to specify which voice to use, check voices() for available values. */
+  iosVoiceId: string;
+  /** Parameter to specify which speech rate this line should be spoken with. Will override default rate if set for this utterance. */
+  rate: number;
+  /** Parameter key to specify the audio hardware output of the TTS. */
+  audioOutput: "speaker" | "earpiece";
+}
+
 export type Options =
   | string
   | {
-      iosVoiceId: string;
-      rate: number;
+      iosParams: IosOptions;
       androidParams: AndroidOptions;
     };
 

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class Tts extends NativeEventEmitter {
     // compatibility with old-style voiceId argument passing
     if (typeof options === 'string') {
       if (Platform.OS === 'ios') {
-        return TextToSpeech.speak(utterance, { iosVoiceId: options });
+        return TextToSpeech.speak(utterance, options.iosParams || {});
       } else {
         return TextToSpeech.speak(utterance, {});
       }


### PR DESCRIPTION
Hi, 
I think the iOS implementation is missing a the part where you can configure the audio output of the TextToSpeak.

I grouped all the iOS Tts option under `iosOptions` to be similiar with the android ones and added a the functionality to change the audio output on iOS.

Kind regards,
Liviu