### PR TITLE
fixes addEventListener TS declaration to return RN.EmitterSubscription

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ export class ReactNativeTts extends RN.NativeEventEmitter {
   addEventListener: <T extends TtsEvents>(
     type: T,
     handler: TtsEventHandler<T>
-  ) => void;
+  ) => RN.EmitterSubscription;
   removeEventListener: <T extends TtsEvents>(
     type: T,
     handler: TtsEventHandler<T>


### PR DESCRIPTION
Actual implementation of Tts class has method
```
addEventListener(type, handler) {
    return this.addListener(type, handler);
  }
```
which returns EmitterSubscription
And the typescript declaration currently does not.
Added it to be able to call remove() on it, since NativeEventEmitter.removeListener is now deprecated 
https://github.com/facebook/react-native/blob/main/Libraries/EventEmitter/NativeEventEmitter.js#L99