### PR TITLE
fix warning isssue 'new NativeEventEmitter()'

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -34,6 +34,16 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
     private Map<String, Locale> localeCountryMap;
     private Map<String, Locale> localeLanguageMap;
 
+    @ReactMethod
+    public void addListener(String eventName) {
+
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+
+    }
+
     public TextToSpeechModule(ReactApplicationContext reactContext) {
         super(reactContext);
         audioManager = (AudioManager) reactContext.getApplicationContext().getSystemService(reactContext.AUDIO_SERVICE);


### PR DESCRIPTION
In this pull request I added the following on _TextToSpeechModule.java_, to remove warning 'new NativeEventEmitter()' :

```
@ReactMethod
public void addListener(String eventName) {

}

@ReactMethod
public void removeListeners(Integer count) {

}
```