### PR TITLE
Fix NativeEventEmitter warnings

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -525,4 +525,14 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(eventName, params);
     }
+    
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void addListener(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
 }


### PR DESCRIPTION
This PR adds empty methods to fix the warnings issued because it does not expose listener methods. It should fix #221 (more infos in [this pr](https://github.com/dotintent/react-native-ble-plx/pull/901))