### PR TITLE
Remove outdated linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ React Native TTS is a text-to-speech library for [React Native](https://facebook
 
 ```shell
 npm install --save react-native-tts
-react-native link react-native-tts
 ```
 
 ## Usage


### PR DESCRIPTION
React-native link is no longer necessary, auto-linking is now implemented.

Also added a .gitignore file for good measure.

https://github.com/ak1394/react-native-tts/issues/259

