### PR TITLE
fix: pause spoken audio like podcast or audiobook

### DIFF
--- a/ios/TextToSpeech/TextToSpeech.m
+++ b/ios/TextToSpeech/TextToSpeech.m
@@ -79,7 +79,13 @@ RCT_EXPORT_METHOD(speak:(NSString *)text
     }
 
     if([_ignoreSilentSwitch isEqualToString:@"ignore"]) {
-        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+        [[AVAudioSession sharedInstance]
+         setCategory:AVAudioSessionCategoryPlayback
+         mode:AVAudioSessionModeVoicePrompt
+         // This will pause a spoken audio like podcast or audiobook and duck the volume for music
+         options:AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers
+         error:nil
+        ];
     } else if([_ignoreSilentSwitch isEqualToString:@"obey"]) {
         [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
     }


### PR DESCRIPTION
This PR fixes the spoken audio on iOS. If the user is listening to a spoken audio like a podcast or audiobook, the TTS should pause the other audio session and duck if a user is listening to music.

https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryoptions/avaudiosessioncategoryoptioninterruptspokenaudioandmixwithothers?language=objc