### PR TITLE
Fix audio session conflict with other voice instances on iOS

### DIFF
--- a/ios/TextToSpeech/TextToSpeech.m
+++ b/ios/TextToSpeech/TextToSpeech.m
@@ -231,6 +231,12 @@ RCT_EXPORT_METHOD(voices:(RCTPromiseResolveBlock)resolve
 
 -(void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didStartSpeechUtterance:(AVSpeechUtterance *)utterance
 {
+    [[AVAudioSession sharedInstance]
+     setCategory:AVAudioSessionCategoryPlayback
+     mode:AVAudioSessionModeVoicePrompt
+     options:AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers
+     error:nil];
+    
     if(_ducking) {
         [[AVAudioSession sharedInstance] setActive:YES error:nil];
     }


### PR DESCRIPTION
## Problem
When using this TTS library alongside other voice-related libraries (like @react-native-voice/voice), TTS sometimes stops working on IOS. This occurs because the audio session is reset (e.g., other libraries reset the audio session), which interferes with TTS functionality.

## Solution
Ensures that TTS functionality remains stable when starting TTS by resolving conflicts with other voice instances.

1. Automatically reconfigures the audio session at the start of each utterance.
2. Prevents audio session conflicts with other voice recognition libraries.

## Changes

```diff
(void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didStartSpeechUtterance:(AVSpeechUtterance *)utterance
{
+    [[AVAudioSession sharedInstance]
+     setCategory:AVAudioSessionCategoryPlayback
+     mode:AVAudioSessionModeVoicePrompt
+     options:AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers
+     error:nil];
    
    if(_ducking) {
        [[AVAudioSession sharedInstance] setActive:YES error:nil];
    }

    [self sendEventWithName:@"tts-start" body:@{@"utteranceId":[NSNumber numberWithUnsignedLong:utterance.hash]}];
}
```

Resolves #275

