### PR TITLE
refactor: removing the deprecated jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,12 +3,18 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
-    repositories {
-        jcenter()
-    }
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    // ref: https://docs.gradle.org/current/userguide/tutorial_using_tasks.html#sec:build_script_external_dependencies
+    if (project == rootProject) {
+        repositories {
+            google()
+        }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        dependencies {
+            classpath 'com.android.tools.build:gradle:1.3.1'
+        }
     }
 }
 


### PR DESCRIPTION
Updated build.gradle to utilize Google repositories for the Android Gradle plugin. The Android 14 upgrade is currently on hold because of the deprecated jcenter method. React Native 0.82 necessitated this change.